### PR TITLE
Fix HSL alpha channel bug.

### DIFF
--- a/color-string.js
+++ b/color-string.js
@@ -87,10 +87,11 @@ function getHsla(string) {
    var hsl = /^hsla?\(\s*(\d+)(?:deg)?\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
    var match = string.match(hsl);
    if (match) {
+      var alpha = parseFloat(match[4]);
       var h = scale(parseInt(match[1]), 0, 360),
           s = scale(parseFloat(match[2]), 0, 100),
           l = scale(parseFloat(match[3]), 0, 100),
-          a = scale(parseFloat(match[4]) || 1, 0, 1);
+          a = scale(isNaN(alpha) ? 1 : alpha, 0, 1);
       return [h, s, l, a];
    }
 }
@@ -102,10 +103,11 @@ function getHwb(string) {
    var hwb = /^hwb\(\s*(\d+)(?:deg)?\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
    var match = string.match(hwb);
    if (match) {
+    var alpha = parseFloat(match[4]);
       var h = scale(parseInt(match[1]), 0, 360),
           w = scale(parseFloat(match[2]), 0, 100),
           b = scale(parseFloat(match[3]), 0, 100),
-          a = scale(parseFloat(match[4]) || 1, 0, 1);
+          a = scale(isNaN(alpha) ? 1 : alpha, 0, 1);
       return [h, w, b, a];
    }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -33,6 +33,9 @@ assert.deepEqual(string.getHwb("hwb(200, 20%, 33%, 0.2)"), [200, 20, 33, 0.2]);
 assert.deepEqual(string.getRgb("#fef"), [255, 238, 255]);
 assert.deepEqual(string.getRgb("rgba(200, 20, 233, 0.2)"), [200, 20, 233]);
 assert.deepEqual(string.getHsl("hsl(240, 100%, 50.5%)"), [240, 100, 50.5]);
+assert.deepEqual(string.getRgba('rgba(0,0,0,0)'), [0, 0, 0, 0]);
+assert.deepEqual(string.getHsla('hsla(0,0%,0%,0)'), [0, 0, 0, 0]);
+assert.deepEqual(string.getHwb("hwb(400, 10%, 200%, 0)"), [360, 10, 100, 0]);
 
 // range
 assert.deepEqual(string.getRgba("rgba(300, 600, 100, 3)"), [255, 255, 100, 1]);


### PR DESCRIPTION
Strange error when parsing a colour such as `hsla(0, 0%, 0%, 0)` - alpha channel gets converted to 1. Fixed this in both the HSL and HWB conversion functions, such that this test now passes:

```js
assert.deepEqual(string.getHsla('hsla(0,0%,0%,0)'), [0, 0, 0, 0]);
```