### PR TITLE
adding license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "node test/basic.js"
   },
+  "license": "MIT",
   "main": "./color-string",
   "dependencies": {
     "color-name": "1.0.x"


### PR DESCRIPTION
We have some automated tools for license checking that our legal team uses. Right now your module is getting flagged as un-licensed since this field is missing.

:smile: 